### PR TITLE
fix: ignore function hash in regression test as the hash changes with updated dependencies that affect the bundled lambda code

### DIFF
--- a/test/__snapshots__/test-against-regression.test.ts.snap
+++ b/test/__snapshots__/test-against-regression.test.ts.snap
@@ -178,12 +178,12 @@ exports[`Tests against regression of synth output has no change in PostsStack Co
             "DYNAMODB_TABLE_NAME": "\${aws_dynamodb_table.posts_storage_table_50F8EECB.name}"
           }
         },
-        "filename": "assets/posts_api_code_lambda-asset_7F9E9FED/8709451AE9543AF31FCAFB7AE82D206E/archive.zip",
+        "filename": "assets/posts_api_code_lambda-asset_7F9E9FED/DUMMY_HASH/archive.zip",
         "function_name": "sls-example-posts-api-developmentregression-test",
         "handler": "index.handler",
         "role": "\${aws_iam_role.posts_api_lambda-exec_B42627E0.arn}",
         "runtime": "nodejs14.x",
-        "source_code_hash": "8709451AE9543AF31FCAFB7AE82D206E"
+        "source_code_hash": "DUMMY_HASH"
       }
     },
     "aws_lambda_permission": {

--- a/test/test-against-regression.test.ts
+++ b/test/test-against-regression.test.ts
@@ -27,6 +27,13 @@ describe("Tests against regression of synth output", () => {
         });
         const stackSynth = JSON.parse(Testing.synth(stack));
         delete stackSynth["terraform"]
+        
+        // this hash changes whenever dependencies are updated that affect the compiled lambda function
+        const actualHash = stackSynth.resource.aws_lambda_function.posts_api_7D5242CA.source_code_hash;
+        stackSynth.resource.aws_lambda_function.posts_api_7D5242CA.source_code_hash = "DUMMY_HASH";
+        stackSynth.resource.aws_lambda_function.posts_api_7D5242CA.filename =
+            stackSynth.resource.aws_lambda_function.posts_api_7D5242CA.filename.replace(actualHash, "DUMMY_HASH");
+
         expect(JSON.stringify(stackSynth, null, 2)).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
We can safely ignore this hash as we don't need to test whether the bundler works, we only care about the structure of the terraform output being correct
